### PR TITLE
Resolve #16

### DIFF
--- a/gradeforge/__init__.py
+++ b/gradeforge/__init__.py
@@ -3,5 +3,5 @@ from .parse import parse_exam, parse_sections, parse_bookstore, parse_catalog, p
 from .download import get_exam, get_sections, get_bookstore, get_catalog, get_grades
 from .sql import TABLES, create, query, dump
 from .web import app
-from .utils import allowed, get_season_today, SingleMetavarFormatter
+from .utils import allowed, get_season_today
 from .combine import combine_grades, combine_instructors, combine_departments, combine_terms

--- a/gradeforge/__main__.py
+++ b/gradeforge/__main__.py
@@ -5,12 +5,13 @@ makefile; if you want to run SQL queries I recommend running `make` then
 from datetime import date
 from sys import stdout
 from os import path
-# I tried making this relative and it failed miserably, not worth the pain
-from gradeforge import *
 import argparse
+# I tried making this relative and it failed miserably, not worth the pain
+from . import *
 
 # override the default help formatter for ArgumentParser to avoid printing
 # duplicate copies of possible parameters
+# pylint: disable=undefined-variable
 argparse.HelpFormatter._format_action_invocation = utils.argparse_format_action_invocation
 
 from argparse import ArgumentParser

--- a/gradeforge/__main__.py
+++ b/gradeforge/__main__.py
@@ -2,20 +2,25 @@
 makefile; if you want to run SQL queries I recommend running `make` then
 `gradeforge sql query <your_query>`.'''
 
-from argparse import ArgumentParser
 from datetime import date
 from sys import stdout
 from os import path
 # I tried making this relative and it failed miserably, not worth the pain
 from gradeforge import *
+import argparse
+
+# override the default help formatter for ArgumentParser to avoid printing
+# duplicate copies of possible parameters
+argparse.HelpFormatter._format_action_invocation = utils.argparse_format_action_invocation
+
+from argparse import ArgumentParser
 
 VERBOSITY = ArgumentParser(add_help=False)
 VERBOSITY.add_argument('--verbose', '--debug', '-v', action='count', default=0)
 # couldn't find a good way to do this in argparse; quiet will later be subtracted from verbose
 VERBOSITY.add_argument('--quiet', '-q', action='count', default=0)
 
-
-PARSER = ArgumentParser(formatter_class=SingleMetavarFormatter, prog='gradeforge',
+PARSER = ArgumentParser(prog='gradeforge',
                         description="backend for the GradeForge app")
 
 SUBPARSERS = PARSER.add_subparsers(dest='subparser', help='commands to run')
@@ -23,7 +28,9 @@ SUBPARSERS = PARSER.add_subparsers(dest='subparser', help='commands to run')
 SUBPARSERS.required = True
 
 # begin web parser
-WEB = SUBPARSERS.add_parser('web', description='run the web server', parents=[VERBOSITY])
+WEB = SUBPARSERS.add_parser('web',
+    description='run the web server',
+    parents=[VERBOSITY])
 WEB.add_argument('--port', '-p', type=int, default=5000)
 
 # begin `parse` parser
@@ -81,8 +88,8 @@ DOWNLOAD.add_argument('--year', '-y', type=int, default=date.today().year,
 INFO = DOWNLOAD.add_subparsers(dest='info')
 INFO.required = True
 
-SECTIONS = INFO.add_parser('sections', description='course sections offered',
-                           formatter_class=SingleMetavarFormatter)
+SECTIONS = INFO.add_parser('sections', description='course sections offered')
+
 # TODO: make campus nicer
 SECTIONS.add_argument('--campus', '-c', choices=allowed['campus'] + ('%',), default='%')
 # TODO: allowed['term'] is a dumpster fire that needs to be nuked from orbit

--- a/gradeforge/utils.py
+++ b/gradeforge/utils.py
@@ -49,24 +49,21 @@ allowed = {'semester': ("201341", "201401", "201405", "201408", "201501", "20150
            'days': ('m', 't', 'w', 'r', 'f', 's', 'u'),
            'credits': range(4)}
 
-# https://stackoverflow.com/a/16969505
-class SingleMetavarFormatter(HelpFormatter):
-    '''For the picky among us.
-    Turns the default: -s ARGS, --long ARGS
-              into:    -s, --long ARGS
-    example: parser = ArgumentParser(formatter_class=SingleMetavarFormatter)'''
-    def _format_action_invocation(self, action):
-        if not action.option_strings:
-            return self._metavar_formatter(action, action.dest)(1)[0]
+def argparse_format_action_invocation(self, action):
+    # this function is used to override
+    # argparse.HelpFormatter._format_action_invocation globally so as to avoid
+    # printing duplicate copies of potential parameters.
 
-        parts = list(action.option_strings)
+    if not action.option_strings:
+        return self._metavar_formatter(action, action.dest)(1)[0]
 
-        # if the Optional takes a value, format is:
-        #    -s, --long ARGS
-        if action.nargs != 0:
-            parts[-1] += ' %s' % self._format_args(action, action.dest.upper())
-        return ', '.join(parts)
+    parts = list(action.option_strings)
 
+    # if the Optional takes a value, format is:
+    #    -s, --long ARGS
+    if action.nargs != 0:
+        parts[-1] += ' %s' % self._format_args(action, action.dest.upper())
+    return ', '.join(parts)
 
 def b_and_n_semester(semester):
     '''Example: 201808 -> F18'''


### PR DESCRIPTION
* SingleMetavarFormatter is now depricated

* utils.py now globally overrides
  argparse.HelpFormatter.format_action_invocation, meaning all
  instantiations of argparse.ArgumentParser() exhibit the same
  properties as those instantiated with SingleMetavarFormatter as the
  formatter.

* Other modules which need this behavior may need to replicate the code
  from utils.py.