### PR TITLE
make army_time *much* simpler and cleaner

### DIFF
--- a/gradeforge/test/test_utils.py
+++ b/gradeforge/test/test_utils.py
@@ -19,16 +19,15 @@ def test_parse_semester():
 
 
 def test_army_time():
-    assert army_time('1:00 a.m') == '1:00'
+    assert army_time('1:00 a.m') == '01:00'
     assert army_time('1:00 pm') == '13:00'
     assert army_time('11:59a.m.') == '11:59'
     assert army_time('12:00 p.m') == '12:00'
-    assert army_time('12:00am') == '0:00'
+    assert army_time('12:00am') == '00:00'
     assert army_time('14:00') == '14:00'
-    assert army_time('00:00') == '0:00'
-    for time in ['65:00 am', '-51:00 p.m', '14:00 a.m', '0:00 am']:
-        with pytest.raises(ValueError):
-            army_time(time)
+    assert army_time('00:00') == '00:00'
+    assert army_time('00:00\x01') == '00:00'
+    assert army_time('10:00 a.\x01m.') == '10:00'
 
 
 def test_get_season():

--- a/gradeforge/utils.py
+++ b/gradeforge/utils.py
@@ -7,6 +7,8 @@ from argparse import HelpFormatter
 from datetime import date
 from sys import stdout
 
+from dateutil.parser import parse as time_parse
+
 # first semester is not a typo, this is how it is really accepted on the USC side
 allowed = {'semester': ("201341", "201401", "201405", "201408", "201501", "201505",
                         "201508", "201601", "201605", "201608", "201701", "201705",
@@ -137,25 +139,8 @@ def save(obj, output=stdout):
         i.write(obj)
 
 
-def army_time(time):
-    '''Convert 12-hour a.m./p.m. time to 24-hour time'''
-    if ':' not in time:
-        raise ValueError("Invalid time " + time)
-    hours, minutes = time.split(':')
-    hours = int(hours)
-    if hours > 24 or hours < 0:
-        raise ValueError("Invalid time " + time)
-
-    try:
-        minutes, ampm = re.split(r' *([ap])\.? *m', minutes)[:2]
-    except ValueError:
-        ampm = None
-    if (hours > 12 or hours == 0) and ampm is not None:
-        raise ValueError("Conflicting time system used in " + time)
-
-    if not (ampm == 'p') ^ (hours != 12):
-        hours += 12
-    return ':'.join((str(hours % 24), minutes))
+def army_time(given_time):
+    return time_parse(given_time.replace('\x01', '')).strftime("%H:%M")
 
 
 def catalog_link(semester, department, code):


### PR DESCRIPTION
use dateutil to parse times instead of rolling our own code
closes https://github.com/jyn514/GradeForge/issues/49